### PR TITLE
Bump docklib to v1.3.0

### DIFF
--- a/requirement_files/docklib.txt
+++ b/requirement_files/docklib.txt
@@ -1,1 +1,1 @@
-docklib==1.2.0
+docklib==1.3.0

--- a/requirements_opinionated.txt
+++ b/requirements_opinionated.txt
@@ -14,7 +14,7 @@ cfgv==3.1.0
 chardet==3.0.4
 click==7.1.2
 distlib==0.3.1
-docklib==1.2.0
+docklib==1.3.0
 docutils==0.16
 entrypoints==0.3
 filelock==3.0.12

--- a/requirements_recommended.txt
+++ b/requirements_recommended.txt
@@ -9,7 +9,7 @@ cfgv==3.1.0
 chardet==3.0.4
 click==7.1.2
 distlib==0.3.1
-docklib==1.2.0
+docklib==1.3.0
 entrypoints==0.3
 filelock==3.0.12
 flake8-bugbear==20.1.4


### PR DESCRIPTION
[Docklib 1.3.0 release](https://github.com/homebysix/docklib/releases/tag/v1.3.0) includes:

### Added

- A new `findExistingEntry` function that can find dock items based on several attributes.

    The default behavior of `findExistingEntry` is to match the provided string on (in order of preference):

    1. label
    2. path
    3. filename with extension
    4. filename without extension

    The `match_on` parameter can be specified to select only one of those attributes to match, if desired. See the `findExistingEntry` function docstring for available parameters and values.

### Changed

- The `findExistingLabel` function is now simply a pointer to the new `findExistingEntry` function. `findExistingLabel` will be maintained for backward-compatibility.

- The `removeDockEntry` function has a new `match_on` parameter that mirrors the same parameter in `findExistingEntry`. Default behavior is to match on the same attributes listed above, in the same order of preference. (This is a change in behavior from previous versions of docklib. If you prefer to continue removing items solely based on label, you should specify `match_on="label"` in your function call.)

- The `replaceDockEntry` function has two new parameters:
    - `match_str`, which allows specifying the item intended to be replaced in the dock (replaces the now deprecated `label` parameter).
    - `match_on`, which mirrors the same parameter in `findExistingEntry`. Default behavior is to match on the same attributes listed above, in the same order of preference.

### Deprecated

- The `label` parameter of `replaceDockEntry` is deprecated, and it's encouraged to use `match_str` instead. This allows existing items to be replaced based on multiple attributes rather than just label. As stated above, this makes dock customization scripts more reliable in multilingual environments.

    A warning has been added that alerts administrators to this deprecation.

- **This is the last release of docklib that will support Python 2.** Future releases will only be tested in Python 3.

    If you haven't started bundling a Python 3 runtime for your management tools, [this blog article from @scriptingosx](https://scriptingosx.com/2020/02/wrangling-pythons/) is a good read. Also: a reminder that docklib is already included in the "recommended" flavor of the [macadmins/python](https://github.com/macadmins/python) packages.
